### PR TITLE
Update Subscript to Calendar button

### DIFF
--- a/src/components/Schedule.js
+++ b/src/components/Schedule.js
@@ -38,6 +38,22 @@ const Schedule = () => {
   const [width, setWidth] = useState(window.innerWidth);
   const [currentTime, setCurrentTime] = useState(new Date());
 
+  // Create the "Subscribe to Calendar" button
+  const defaultCopyButtonText = 'Subscribe to Calendar';
+  const [copyButtonText, setCopyButtonText] = useState(defaultCopyButtonText);
+  const copySubscribeLink = () => {
+    var textArea = document.createElement('textarea');
+    textArea.value = "https://calendar.google.com/calendar/ical/c_n3lvtno6l4rebktvvqus3vpb2c%40group.calendar.google.com/public/basic.ics";
+    document.body.appendChild(textArea);
+    textArea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textArea);
+    setCopyButtonText('iCalendar Link Copied!');
+    setTimeout(() => {
+      setCopyButtonText(defaultCopyButtonText);
+    }, 1500);
+  };
+
   useEffect(() => {
     const updateSize = () => {
       setWidth(window.innerWidth);
@@ -61,8 +77,8 @@ const Schedule = () => {
           <h1>Event Schedule</h1>
         </Col>
         <Col>
-          <a href="https://calendar.google.com/calendar/ical/c_n3lvtno6l4rebktvvqus3vpb2c%40group.calendar.google.com/public/basic.ics">
             <button
+              onClick={copySubscribeLink}
               type="button"
               className="btn secondary-cta schedule__export"
             >
@@ -71,9 +87,8 @@ const Schedule = () => {
                 className="schedule__calendar"
                 alt="Calendar Icon"
               />
-              Subscribe to Calendar
+              {copyButtonText}
             </button>
-          </a>
         </Col>
       </Row>
       <Row>


### PR DESCRIPTION
Making the "Subscribe to Calendar" button a copy-able link instead of a download link. The text of the button now changes for a short time after you click it to let you know the link has been copied. 

*Note: I copied the code for this from the "Copy email template" feature on the the [build projects page](https://buildforblacklives.com/projects)* (when you request to work on a project).

![image](https://user-images.githubusercontent.com/23193756/108407438-bb65cc80-71f1-11eb-8d57-7849a84c456f.png)
![image](https://user-images.githubusercontent.com/23193756/108407499-cb7dac00-71f1-11eb-9aae-123dfa945165.png)


