### PR TITLE
Update copy, add team spacing

### DIFF
--- a/src/components/Schedule.js
+++ b/src/components/Schedule.js
@@ -105,10 +105,11 @@ const Schedule = () => {
               {" "}
               here
             </a>
-            .
+            . 
+            <br/>The password for all Zoom meetings can be found pinned in the #announcements Slack channel.
           </h3>
           <h3 className="schedule__warning">
-            Please be sure to attend all events labeled "Everyone"
+            Please be sure to attend all events labeled "Everyone".
           </h3>
         </Col>
       </Row>

--- a/src/components/Team.js
+++ b/src/components/Team.js
@@ -115,7 +115,6 @@ const Team = () => {
         </Row>
         <Container>
           <Row className="py-3">
-            <Col lg="1"></Col>
             {
               isLoading && (
                 <Spinner animation="border" variant="primary" />


### PR DESCRIPTION
Add a note about zoom passwords & remove the spacing in the team section to make more space for tech members

![image](https://user-images.githubusercontent.com/23193756/108540769-9899ed80-72af-11eb-8a3c-08a90f62eddf.png)
![image](https://user-images.githubusercontent.com/23193756/108540840-aea7ae00-72af-11eb-82a2-94568466fd42.png)
